### PR TITLE
part 2 of the script that will import stuck reportback submissions.

### DIFF
--- a/gambit-stuck-submissions-import/README.md
+++ b/gambit-stuck-submissions-import/README.md
@@ -2,12 +2,16 @@
 This script will attempt to resubmit all "stuck" submissions that belong to the currently active campaigns.
 
 # How to use
+#### Test
+Run `NODE_ENV=test npm start`
+- NOTE: Will re-post reportbacks to a mock server at localhost:9001.
+
 #### Development
-Run `LOGGING_LEVEL=debug npm start`
+Run `NODE_ENV=development npm start`
 - NOTE: Will by default re post reportbacks to gambit localhost. Will use the gambit localhost as base url and generic gambit API key.
 
 #### Production 🚨
-Run `LOGGING_LEVEL=debug NODE_ENV=production npm start`
+Run `NODE_ENV=production npm start`
 - ⚠️: Will re post reportbacks using the base url and gambit API key stored in your `.env` file. Potentially impacting real, production users.
 
 # Some things to consider

--- a/gambit-stuck-submissions-import/README.md
+++ b/gambit-stuck-submissions-import/README.md
@@ -1,0 +1,24 @@
+# Gambit stuck submissions import
+This script will attempt to resubmit all "stuck" submissions that belong to the currently active campaigns.
+
+# How to use
+#### Development
+Run `LOGGING_LEVEL=debug npm start`
+- NOTE: Will by default re post reportbacks to gambit localhost. Will use the gambit localhost as base url and generic gambit API key.
+
+#### Production 🚨
+Run `LOGGING_LEVEL=debug NODE_ENV=production npm start`
+- ⚠️: Will re post reportbacks using the base url and gambit API key stored in your `.env` file. Potentially impacting real, production users.
+
+# Some things to consider
+- This script will **only** re-post reportbacks **directly** to Gambit that:
+  - belong to currently running campaigns.
+  - **Do not** have a `submitted_at` property.
+  - **Have** a `failed_at` property.
+  - It's user **has** a `mobilecommons_id` property.
+  - It's user **has** a `phoenix_id` property.
+- If the reportback does not meet the above, it will not be re-posted.
+
+# FAQ
+- What do you mean by stuck?
+> Some reportbacks might have failed due to bugs. These submissions remain in a state of failure in the Gambit database until the bug is fixed. Once fixed, we can run this script to resubmit these reportbacks.

--- a/gambit-stuck-submissions-import/README.md
+++ b/gambit-stuck-submissions-import/README.md
@@ -19,8 +19,8 @@ Run `NODE_ENV=production npm start`
   - belong to currently running campaigns.
   - **Do not** have a `submitted_at` property.
   - **Have** a `failed_at` property.
-  - It's user **has** a `mobilecommons_id` property.
-  - It's user **has** a `phoenix_id` property.
+  - Its user **has** a `mobilecommons_id` property.
+  - Its user **has** a `phoenix_id` property.
 - If the reportback does not meet the above, it will not be re-posted.
 
 # FAQ

--- a/gambit-stuck-submissions-import/README.me
+++ b/gambit-stuck-submissions-import/README.me
@@ -1,9 +1,0 @@
-# Gambit stuck submissions import
-This script will attempt to resubmit all "stuck" submissions that belong to the currently active campaigns.
-
-# How to use
-Run `LOGGING_LEVEL=debug npm start`
-
-# FAQ
-- What do you mean by stuck?
-> Some reportbacks might have failed due to bugs. These submissions remain in a state of failure in the Gambit database until the bug is fixed. Once fixed, we can run this script to resubmit these reportbacks.

--- a/gambit-stuck-submissions-import/config/lib/gambit.js
+++ b/gambit-stuck-submissions-import/config/lib/gambit.js
@@ -1,0 +1,11 @@
+const configVars = {};
+
+if (process.env.NODE_ENV === 'production') {
+  configVars.baseURL = process.env.GAMBIT_API_BASE_URL;
+  configVars.gambitAPIKey = process.env.GAMBIT_API_KEY;
+}else {
+  configVars.baseURL = 'http://localhost:5000/v1';
+  configVars.gambitAPIKey = 'totallysecret';
+}
+
+module.exports = configVars;

--- a/gambit-stuck-submissions-import/config/lib/gambit.js
+++ b/gambit-stuck-submissions-import/config/lib/gambit.js
@@ -1,9 +1,14 @@
 const configVars = {};
 
-if (process.env.NODE_ENV === 'production') {
+configVars.environment = process.env.NODE_ENV;
+
+if (configVars.environment === 'production') {
   configVars.baseURL = process.env.GAMBIT_API_BASE_URL;
   configVars.gambitAPIKey = process.env.GAMBIT_API_KEY;
-}else {
+} else if (configVars.environment === 'test') {
+  configVars.baseURL = 'http://localhost:9001';
+  configVars.gambitAPIKey = 'totallysecret';
+} else {
   configVars.baseURL = 'http://localhost:5000/v1';
   configVars.gambitAPIKey = 'totallysecret';
 }

--- a/gambit-stuck-submissions-import/index.js
+++ b/gambit-stuck-submissions-import/index.js
@@ -3,10 +3,15 @@ const logger = require('winston');
 const underscore = require('underscore');
 const Promise = require('bluebird');
 const queryString = require('querystring');
+const http =  require('http');
+const mockserver = require('mockserver');
 
 const config = require('./config');
 const GambitService = require('./lib/gambit');
 const BatchProcessor = require('./lib/batchProcessor');
+
+// TODO: use config?
+const testServer = http.createServer(mockserver('./mocks')).listen(9001);
 
 function getCampaignsAndKeyword(campaigns) {
   const campaignsMap = {};
@@ -130,6 +135,7 @@ async function importStuckSubmissions(submissionsPerCampaign = [], users = []) {
 
 async function cleanUp() {
   const db = await getDB()
+  testServer.close();
   return db.close();
 }
 

--- a/gambit-stuck-submissions-import/index.js
+++ b/gambit-stuck-submissions-import/index.js
@@ -2,9 +2,11 @@ const fetch = require('node-fetch');
 const logger = require('winston');
 const underscore = require('underscore');
 const Promise = require('bluebird');
+const queryString = require('querystring');
 
 const config = require('./config');
 const GambitService = require('./lib/gambit');
+const BatchProcessor = require('./lib/batchProcessor');
 
 function getCampaignsAndKeyword(campaigns) {
   const campaignsMap = {};
@@ -12,6 +14,30 @@ function getCampaignsAndKeyword(campaigns) {
     campaignsMap[campaign.id] = underscore.first(campaign.keywords).keyword;
   });
   return campaignsMap;
+}
+
+function getUserIds(campaigns) {
+  const usersArray = campaigns.map((campaign) => {
+    const users = [];
+    campaign.submissions.forEach((reportback) => {
+      users.push(reportback.user);
+    });
+    return users;
+  });
+
+  // TODO: Should we use underscore.compact? Are we ever going to get null for an user here?
+  return underscore.uniq(underscore.flatten(usersArray));
+}
+
+async function getUsers(ids = []) {
+  const db = await getDB();
+  let users;
+  try {
+    users = await db.collection('users').find({ _id: { $in: ids }}).toArray();
+  } catch (error) {
+    logger.error(error);
+  }
+  return users;
 }
 
 async function getStuckSubmissionsByCampaign(campaigns) {
@@ -38,6 +64,11 @@ async function getStuckSubmissionsByCampaign(campaigns) {
   // query the production gambit database to gather all stuck submissions that belong to the current running campaigns (see above)
   try {
     submissions = await db.collection('reportback_submissions').aggregate(aggregator).toArray();
+    // Inject keyword into the reportback submission
+    mappedSubmissions = submissions.map((submission) => {
+      const keyword = campaigns[submission._id];
+      return submission.keyword = keyword;
+    });
   } catch(error) {
     logger.error(error);
   }
@@ -46,13 +77,55 @@ async function getStuckSubmissionsByCampaign(campaigns) {
 
 // Once we have identified these stuck submissions, re POST to chatbot route with:
 // - the number of the user
-// - the madeup profile id
+// - the user's mobilecommons profile id
 // - the submissions campaign keyword
 //
-// Also, lets post with a delay of 5 seconds per request, just to be extremelly conservative
-async function importStuckSubmissions(submissions = []) {
-  const gambit = new GambitService();
-  logger.info(submissions);
+// Also, lets post with a delay of 5 seconds per batch, just to be extremelly conservative
+async function importStuckSubmissions(submissionsPerCampaign = [], users = []) {
+  const batchProcessor = new BatchProcessor({
+    intervalWaitInMs: 5000,
+    batchSize: 2
+  });
+  const gambit = new GambitService({}, batchProcessor);
+
+  gambit.on('done', async (errors, processed) => {
+    logger.info(`Finished processing ${processed.length} requests!`);
+    logger.info(`There were ${errors.length} errors!`);
+
+    if (errors.length) {
+      errors.forEach((error) => {
+        logger.error(`This request: ${JSON.stringify(error.request)}\r\nFailed with the following error: ${error.error}`);
+      })
+    }
+    await cleanUp();
+  });
+
+  submissionsPerCampaign.forEach((campaign) => {
+    const keyword = campaign.keyword;
+
+    campaign.submissions.forEach((reportback) => {
+      const user = users.find((user) => user._id === reportback.user);
+
+      // Do not retry users that have no:
+      // mobilecommons_id
+      // phoenix_id
+      if (!user.phoenix_id || !user.mobilecommons_id) {
+        return false;
+      }
+
+      const request = {
+        method: 'post',
+        endpoint: '/chatbot',
+        data: queryString.stringify({
+          phone: user.mobile,
+          profile_id: user.mobilecommons_id,
+          keyword: keyword,
+        }),
+      }
+      gambit.enqueueRequest(request);
+    });
+  });
+  gambit.startBatchProcess();
 }
 
 async function cleanUp() {
@@ -74,8 +147,9 @@ async function init() {
   const campaigns = await fetchCurrentCampaigns();
   const campaignsWithKeyword = getCampaignsAndKeyword(campaigns);
   const stuckSubmissions = await getStuckSubmissionsByCampaign(campaignsWithKeyword);
-  await importStuckSubmissions(stuckSubmissions);
-  await cleanUp();
+  const userIds = getUserIds(stuckSubmissions);
+  const users = await getUsers(userIds);
+  await importStuckSubmissions(stuckSubmissions, users);
 }
 
 init();

--- a/gambit-stuck-submissions-import/lib/batchProcessor.js
+++ b/gambit-stuck-submissions-import/lib/batchProcessor.js
@@ -1,0 +1,69 @@
+const eventEmitter = require('events');
+const underscore = require('underscore');
+
+const defaults = {
+  intervalWaitInMs: 2000,
+  batchSize: 2,
+  batchIntervalId: null
+};
+
+class BatchProcessor extends eventEmitter {
+  constructor(options) {
+    super();
+    this.options = underscore.extend({}, defaults, options);
+    this.queue = [];
+    this.processed = [];
+
+    this.processsing = false;
+  }
+  enqueue(task) {
+    this.queue.push(task);
+  }
+  dequeue(){
+    return this.queue.shift();
+  }
+  processBatch() {
+    const leftToProcess = this.queue.length;
+    const keepProcessing = (leftToProcess - this.options.batchSize) <= 0 ? false : true;
+    let processed = 0;
+    let processThisMany;
+
+    if (!keepProcessing) {
+      this.stopProcessing();
+      processThisMany = leftToProcess;
+    }else {
+      processThisMany = this.options.batchSize;
+    }
+
+    while (processed < processThisMany) {
+      const task = this.dequeue();
+      this.processed.push(task.cb(task.args));
+      processed += 1;
+    }
+    return true;
+  }
+  start() {
+    if (!this.queue.length || this.processsing === true) {
+      return false;
+    }
+    this.options.batchIntervalId = setInterval(() => {
+      this.processBatch();
+    }, this.options.intervalWaitInMs);
+  }
+  stopProcessing() {
+    clearInterval(this.options.batchIntervalId);
+    this.options.batchIntervalId = defaults.batchIntervalId;
+
+    setTimeout(() => {
+      this.emit('done', this.processed);
+      this.resetQueues();
+      this.processsing = false;
+    }, this.options.intervalWaitInMs);
+  }
+  resetQueues() {
+    this.queue = [];
+    this.processed = [];
+  }
+}
+
+module.exports = BatchProcessor;

--- a/gambit-stuck-submissions-import/lib/gambit.js
+++ b/gambit-stuck-submissions-import/lib/gambit.js
@@ -34,12 +34,12 @@ class GambitService extends eventEmitter {
       this.emit('done', this.errors, processed);
     });
 
-    this.on('sent', (response) => {
-      logger.info(`Successfully sent request. Status: ${response.status}. Data: ${JSON.stringify(response.data)}`);
+    this.on('sent', (response, request) => {
+      logger.info(`Successfully sent request: ${JSON.stringify(request)} with status: ${response.status}. and response data: ${JSON.stringify(response.data)}`);
     });
 
-    this.on('error', (error) => {
-      logger.error(`Error processing a request: ${error}`);
+    this.on('error', (error, request) => {
+      logger.error(`Error processing a request: ${JSON.stringify(request)} The error was: ${JSON.stringify(error)}`);
     });
   }
   enqueueRequest(request) {
@@ -49,16 +49,17 @@ class GambitService extends eventEmitter {
     });
   }
   send({ method = 'post', endpoint, data = {}, options = {} }) {
+    const request = { method, endpoint, data, options };
     if (method.toLowerCase() === 'post') {
       return this.client.post(endpoint, data, options)
         .then((response) => {
-          this.emit('sent', response);
+          this.emit('sent', response, request);
         })
         .catch((error) => {
-          this.emit('error', error);
+          this.emit('error', error, request);
           this.errors.push({
             error,
-            request: { method, endpoint, data, options }
+            request
           });
         });
     }

--- a/gambit-stuck-submissions-import/lib/gambit.js
+++ b/gambit-stuck-submissions-import/lib/gambit.js
@@ -1,21 +1,69 @@
 const axios = require('axios');
 const underscore = require('underscore');
+const logger = require('winston');
+const eventEmitter = require('events');
+const assert = require('assert');
+
+const config = require('../config/lib/gambit');
+const BatchProcessor = require('./batchProcessor');
 
 const defaults = {
-  baseURL: process.env.GAMBIT_API_BASE_URL,
+  baseURL: config.baseURL,
   timeout : 29000,
   headers: {
-    'x-gambit-api-key': process.env.GAMBIT_API_KEY,
-  }
+    'x-gambit-api-key': config.gambitAPIKey,
+    'Content-Type': 'application/x-www-form-urlencoded',
+  },
 };
 
-class GambitService {
-  constructor(options) {
-    this.config = underscore.extend({}, defaults, options);
-    this.client = axios.create(this.config);
+class GambitService extends eventEmitter {
+  constructor(options = {}, batchProcessor) {
+    super();
+    this.options = underscore.extend({}, defaults, options.http || {});
+    this.client = axios.create(this.options);
+    this.batchProcessor = batchProcessor ? batchProcessor : new BatchProcessor();
+    this.errors = [];
+    this.setupEventHandlers();
   }
-  post(endpoint, data = {}, options = {}) {
-    return this.client.post(endpoint, data, options);
+  setupEventHandlers(){
+    if (!this.batchProcessor instanceof eventEmitter) {
+      throw new Error('This batchProcessor doesn\'t support events.');
+    }
+    this.batchProcessor.on('done', (processed) => {
+      this.emit('done', this.errors, processed);
+    });
+
+    this.on('sent', (response) => {
+      logger.info(`Successfully sent request. Status: ${response.status}. Data: ${JSON.stringify(response.data)}`);
+    });
+
+    this.on('error', (error) => {
+      logger.error(`Error processing a request: ${error}`);
+    });
+  }
+  enqueueRequest(request) {
+    this.batchProcessor.enqueue({
+      args: request,
+      cb: this.send.bind(this),
+    });
+  }
+  send({ method = 'post', endpoint, data = {}, options = {} }) {
+    if (method.toLowerCase() === 'post') {
+      return this.client.post(endpoint, data, options)
+        .then((response) => {
+          this.emit('sent', response);
+        })
+        .catch((error) => {
+          this.emit('error', error);
+          this.errors.push({
+            error,
+            request: { method, endpoint, data, options }
+          });
+        });
+    }
+  }
+  startBatchProcess() {
+    this.batchProcessor.start();
   }
 }
 

--- a/gambit-stuck-submissions-import/lib/gambit.js
+++ b/gambit-stuck-submissions-import/lib/gambit.js
@@ -19,7 +19,8 @@ const defaults = {
 class GambitService extends eventEmitter {
   constructor(options = {}, batchProcessor) {
     super();
-    this.options = underscore.extend({}, defaults, options.http || {});
+    this.test = config.environment === 'test';
+    this.options = underscore.extend({}, defaults, options || {});
     this.client = axios.create(this.options);
     this.batchProcessor = batchProcessor ? batchProcessor : new BatchProcessor();
     this.errors = [];

--- a/gambit-stuck-submissions-import/mocks/chatbot/POST.mock
+++ b/gambit-stuck-submissions-import/mocks/chatbot/POST.mock
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+
+{
+   "message": "It's all good! 😁"
+}

--- a/gambit-stuck-submissions-import/package.json
+++ b/gambit-stuck-submissions-import/package.json
@@ -4,8 +4,7 @@
   "description": "Submissions get stuck for X reasons in Gambit. This script will attempt to re-POST the submissions through Gambit /chatbot",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js",
-    "test": ""
+    "start": "node index.js"
   },
   "engines": {
     "node": "7.7.2"
@@ -17,6 +16,7 @@
     "axios": "^0.16.1",
     "bluebird": "^3.5.0",
     "dotenv": "^4.0.0",
+    "mockserver": "^1.6.2",
     "mongodb": "^2.2.27",
     "node-fetch": "^1.7.0",
     "underscore": "^1.8.3",


### PR DESCRIPTION
## How to Test
- 👀 
- Update your .env to have all production variables
- Run `npm i`
- Run `NODE_ENV=test npm start` from `odoyle-scripts/gambit-stuck-submissions-import/`
- You should see all stuck reportbacks being re-posted to the included test API.